### PR TITLE
issue/21,20,18 General fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,7 @@ The following attributes are set within *course.json*:
 - Content is not set to explicitly fill the browser width. If required, additional styling should be added to the theme, as the look and feel will be dependant upon the Art Direction and plugins to be used.
 
 - Not designed to work with a page-header. As the extension fills the viewport, all content should be added as components.
+
+- Currently not setup to work with [**adapt-contrib-trickle**](https://github.com/adaptlearning/adapt-contrib-trickle). Instead, blocks are step-locked until completed. Mark blocks as _isOptional to disable step-locking.
+
+- Currently not setup to work with [**adapt-contrib-pageLevelProgress**](https://github.com/adaptlearning/adapt-contrib-). Do not use with other plugins that permit navigation (e.g. adapt-devtools map), including use of `Adapt.navigateToElement`.

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "adapt-scrollSnap",
-  "version": "3.3.1",
-  "framework": ">=5.19",
+  "version": "4.0.0",
+  "framework": ">=5.19.2",
   "displayName" : "ScrollSnap",
   "extension" : "scrollSnap",
   "description": "An extension which hides the scrollbar and snaps to blocks. Content is set to fill the viewport height.",

--- a/example.json
+++ b/example.json
@@ -2,7 +2,13 @@
   "_scrollSnap": {
     "_isEnabled": true,
     "_useNavigationOffset": false,
-    "_scrollDuration": 800,
+    "_scrollDuration": {
+      "_previous": 400,
+      "_next": 400
+    },
+    "_isSwipeEnabled": true,
+    "_isGlobalMenuScroll": true,
+    "_isGlobalNotifyScroll": true,
     "_navigation": {
       "_isEnabled": true,
       "_buttons": {
@@ -16,16 +22,27 @@
           "_classes": "",
           "label": "Continue"
         },
-        "_scroll": {
-          "_isEnabled": true,
-          "_classes": "is-scrollable",
-          "label": "Scroll down"
-        },
         "_last": {
           "_isEnabled": false,
           "_classes": "",
           "label": "Scroll to top"
         }
+      },
+      "_prompts": {
+        "_scroll": {
+          "_isEnabled": true,
+          "_classes": "",
+          "label": "Scroll down"
+        }
       }
     }
-  },
+  }
+
+// optional blocks.json configurations
+  "_scrollSnap": {
+    "_htmlClasses": "",
+    "_preSnap": {
+      "_isReRender": false,
+      "_isReset": false
+    }
+  }

--- a/js/Device.js
+++ b/js/Device.js
@@ -44,6 +44,7 @@ export default class Device extends Backbone.Controller {
     this._isFullscreenChange = false;
     if (!Config.canUseScrollSnap || isFullscreen || isFullscreenResize) return;
     Snap.toId(State.locationId, 0, true);
+    Navigation.update();
   }
 
   onDeviceChanged(screenSize) {

--- a/js/Focus.js
+++ b/js/Focus.js
@@ -1,0 +1,28 @@
+// import Models from './Models';
+import _ from 'underscore';
+import Snap from './Snap';
+// import State from './State';
+
+/**
+ * This section is expressly for keyboard tabbing only
+ * TODO: finish Snap.scroll function for to property
+ */
+export default class Focus extends Backbone.Controller {
+
+  initialize() {
+    _.bindAll(this, 'onFocusIn');
+  }
+
+  addEvents() {
+    $('body').on('focusin', this.onFocusIn);
+  }
+
+  removeEvents() {
+    $('body').off('focusin', this.onFocusIn);
+  }
+
+  onFocusIn(e) {
+    _.defer(() => Snap.scroll({ to: e.target }));
+  }
+
+}

--- a/js/Keyboard.js
+++ b/js/Keyboard.js
@@ -18,13 +18,21 @@ export default class Keyboard extends Backbone.Controller {
     const key = event.key || event.code || event.keyCode;
     // disable arrow keys to avoid conflict with screen readers
     switch (key) {
-      // case 'ArrowUp':
+      case 'ArrowUp':
+      case 38:
+        if (!event.altKey) return;
+        Snap.scroll({ direction: 'up' });
+        break;
+      case 'ArrowDown':
+      case 40:
+        if (!event.altKey) return;
+        Snap.scroll({ direction: 'down' });
+        break;
       case 'PageUp':
       case 33:
       // case 38:
         Snap.up();
         break;
-      // case 'ArrowDown':
       case 'PageDown':
       case 34:
       // case 40:

--- a/js/Menu.js
+++ b/js/Menu.js
@@ -1,0 +1,44 @@
+import Adapt from 'core/js/adapt';
+import Config from './Config';
+import ScrollControlsView from './ScrollControlsView';
+
+export default class Menu extends Backbone.Controller {
+
+  initialize() {
+    this.hasAddedEvents = false;
+    this.isGlobal = Config.global._isGlobalMenuScroll ?? true;
+    if (this.isGlobal) this.addEvents();
+  }
+
+  addEvents() {
+    if (this.isGlobal && this.hasAddedEvents) return;
+    this.hasAddedEvents = true;
+    this.listenTo(Adapt, {
+      'menuView:postRender': this.onMenuViewPostRender,
+      remove: this.onRemove
+    });
+  }
+
+  removeEvents() {
+    if (this.isGlobal) return;
+    this.stopListening(Adapt, {
+      'menuView:postRender': this.onMenuViewPostRender,
+      remove: this.onRemove
+    });
+  }
+
+  onMenuViewPostRender(view) {
+    this.view = view;
+    this.view.scrollControlsView = new ScrollControlsView({
+      $parent: $('body'),
+      $scrollContainer: $('html')
+    });
+  }
+
+  onRemove() {
+    if (!this.view) return;
+    this.view.scrollControlsView.remove();
+    this.view = null;
+  }
+
+}

--- a/js/Navigation.js
+++ b/js/Navigation.js
@@ -37,7 +37,6 @@ export default class Navigation extends Backbone.Controller {
     if (!this._view) return;
     const model = State.currentModel;
     const config = this.getModelConfig(model);
-    config._isScrollAtEnd = Views.isScrollingAtEnd(Views.currentBlockView);
     this._view.model.set(config);
   }
 
@@ -46,15 +45,20 @@ export default class Navigation extends Backbone.Controller {
     const modelConfig = Config.getModelConfig(model)?._navigation;
     const isEnabled = modelConfig?._isEnabled ?? config?._isEnabled;
     const blockIndex = Models.blocks.indexOf(model);
+    const view = Views.currentBlockView;
     // deep merge to prevent removal of nested object data
     const data = $.extend(true, config, modelConfig, {
       _id: model.get('_id'),
       _isEnabled: isEnabled,
-      _isVisible: true,
+      _isVisible: this._view?.model.get('_isVisible') ?? true,
       _isComplete: model?.get('_isComplete') ?? false,
-      _isStepLocked: Models.isBlockStepLocked(model),
+      _isStepLocked: Models.stepLockedBlockIndex > -1 && Models.stepLockedBlockIndex <= blockIndex, // Models.isBlockStepLocked(model),
       _isFirst: Models.isFirstIndex(blockIndex),
-      _isLast: Models.isLastIndex(blockIndex)
+      _isLast: Models.isLastIndex(blockIndex),
+      _hasScrolling: Views.hasScrolling(view),
+      _isScrollAtStart: Views.isScrollingAtStart(view),
+      _isScrollAtEnd: Views.isScrollingAtEnd(view),
+      _isScrollComplete: view?._isScrollComplete ?? false
     });
     return data;
   }

--- a/js/NavigationView.js
+++ b/js/NavigationView.js
@@ -13,12 +13,13 @@ export default class NavigationView extends Backbone.View {
     return {
       'click .js-btn-previous': 'onPreviousClick',
       'click .js-btn-next': 'onNextClick',
+      'click .js-btn-scroll': 'onNextClick',
       'click .js-btn-last': 'onLastClick'
     };
   }
 
   initialize({ Snap }) {
-    this.changed = _.debounce(this.changed, 500);
+    this.changed = _.debounce(this.changed, 50);
     this.Snap = Snap;
     this.listenTo(this.model, 'change', this.changed);
     this.render();
@@ -37,10 +38,12 @@ export default class NavigationView extends Backbone.View {
   }
 
   onPreviousClick() {
+    if (this.Snap.scroll({ direction: 'up' })) return;
     this.Snap.previous();
   }
 
   onNextClick() {
+    if (this.Snap.scroll({ direction: 'down' })) return;
     this.Snap.next();
   }
 

--- a/js/Notify.js
+++ b/js/Notify.js
@@ -1,0 +1,41 @@
+import Adapt from 'core/js/adapt';
+import Config from './Config';
+import ScrollControlsView from './ScrollControlsView';
+
+export default class Notify extends Backbone.Controller {
+
+  initialize() {
+    this.hasAddedEvents = false;
+    this.isGlobal = Config.global._isGlobalNotifyScroll ?? true;
+    if (this.isGlobal) this.addEvents();
+  }
+
+  addEvents() {
+    if (this.isGlobal && this.hasAddedEvents) return;
+    this.hasAddedEvents = true;
+    this.listenTo(Adapt, {
+      'notify:opened': this.onNotifyOpened,
+      'notify:closed': this.onNotifyClosed
+    });
+  }
+
+  removeEvents() {
+    if (this.isGlobal) return;
+    this.stopListening(Adapt, {
+      'notify:opened': this.onNotifyOpened,
+      'notify:closed': this.onNotifyClosed
+    });
+  }
+
+  onNotifyOpened(view) {
+    view.scrollControlsView = new ScrollControlsView({
+      $parent: view.$el,
+      $scrollContainer: view.$('.notify__popup')
+    });
+  }
+
+  onNotifyClosed(view) {
+    view.scrollControlsView.remove();
+  }
+
+}

--- a/js/Page.js
+++ b/js/Page.js
@@ -1,4 +1,6 @@
 import Adapt from 'core/js/adapt';
+import Data from 'core/js/data';
+import Location from 'core/js/location';
 import Classes from './Classes';
 import Models from './Models';
 import State from './State';
@@ -41,7 +43,7 @@ export default class Page extends Backbone.Controller {
     this._controller.addEvents();
     Classes.addHtmlClasses();
     Models.updateLocking();
-    let model = Adapt.findById(Adapt.location._currentId);
+    let model = Data.findById(Location._currentId);
     if (!Models.isBlock(model)) model = Models.blocks[0];
     State.currentModel = model;
   }
@@ -53,10 +55,9 @@ export default class Page extends Backbone.Controller {
 
   onPageReady(view) {
     if (!Views.isScrollSnapActive) return;
+    State.canSnap = true;
     Snap.toId(State.currentModel.get('_id'), 0);
-    State.canSnap = false;
     Adapt.trigger('scrollsnap:start');
-    _.delay(() => { State.canSnap = true; }, 300);
   }
 
   onPagePreRemove(view) {
@@ -79,7 +80,7 @@ export default class Page extends Backbone.Controller {
     _.defer(() => {
       Adapt.set('_canScroll', true, options);
       let id = selector.replace('.', '');
-      let model = Adapt.findById(id);
+      let model = Data.findById(id);
       if (!model) return;
       if (Models.isComponent(model)) {
         model = model.getParent();

--- a/js/ScrollControlsView.js
+++ b/js/ScrollControlsView.js
@@ -1,0 +1,57 @@
+import Backbone from 'backbone';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { templates } from 'core/js/reactHelpers';
+import _ from 'underscore';
+
+export default class ScrollControlsView extends Backbone.View {
+
+  className() {
+    return 'scrollsnap__controls';
+  }
+
+  initialize({ $parent, $scrollContainer }) {
+    _.bindAll(this, 'onClick', 'onScroll', 'onResize');
+    this.$parent = $parent;
+    this.$scrollContainer = $scrollContainer;
+    this.$scrollContainer.on({
+      scroll: this.onScroll,
+      resize: this.onResize
+    });
+    this.$parent.append(this.$el);
+    this.render();
+    this.onResize();
+  }
+
+  render() {
+    const props = {
+      onClick: this.onClick
+    };
+    ReactDOM.render(<templates.ScrollControls {...props} />, this.el);
+  }
+
+  onClick(event) {
+    const direction = $(event.currentTarget).data('direction');
+    this.$scrollContainer[0].scrollTop += direction === 'up' ? -80 : 80;
+  }
+
+  onScroll() {
+
+  }
+
+  onResize() {
+    const windowHeight = $(window).height();
+    const scrollingHeight = parseInt(this.$scrollContainer.find('> *').outerHeight() || this.$scrollContainer.outerHeight());
+    const isFullWindow = (scrollingHeight > windowHeight);
+    this.$el.toggleClass('is-full-window', isFullWindow);
+  }
+
+  remove() {
+    this.$scrollContainer.off({
+      scroll: this.onScroll,
+      resize: this.onResize
+    });
+    super.remove();
+  }
+
+}

--- a/js/State.js
+++ b/js/State.js
@@ -65,11 +65,12 @@ export default class State {
   }
 
   static get isTrickleEnabled() {
-    return Adapt.parentView?.model?.findDescendantModels('component').some(component => component.get('_component') === 'trickle-button');
+    return this._isTrickleEnabled && Adapt.parentView?.model?.findDescendantModels('component').some(component => component.get('_component') === 'trickle-button');
   }
 
   static set isTrickleEnabled(isEnabled) {
-    if (!this.isTrickleEnabled) return;
+    this._isTrickleEnabled = isEnabled;
+    if (!this._isTrickleEnabled) return;
     Adapt.blocks.forEach(block => {
       block.getChildren().where({ _component: 'trickle-button' }).forEach(trickleButton => {
         trickleButton.set('_isAvailable', isEnabled);

--- a/js/Touch.js
+++ b/js/Touch.js
@@ -1,3 +1,4 @@
+import Notify from 'core/js/notify';
 import Views from './Views';
 import State from './State';
 import Scroll from './Scroll';
@@ -24,10 +25,12 @@ export default class Touch extends Backbone.Controller {
   }
 
   onTouchStart(event) {
+    if (Notify.stack.length > 0) return;
     this._start = event;
   }
 
   onTouchMove(event) {
+    if (Notify.stack.length > 0) return;
     event.preventDefault();
     event.deltaY = (event.touches[0].clientY - this._start.touches[0].clientY);
     // check to see if section can be scrolled further here
@@ -52,6 +55,7 @@ export default class Touch extends Backbone.Controller {
   }
 
   onTouchEnd() {
+    if (Notify.stack.length > 0) return;
     State.canSnap = true;
     Navigation.update();
   }

--- a/js/Views.js
+++ b/js/Views.js
@@ -39,6 +39,7 @@ export default class Views {
   }
 
   static hasScrolling(view) {
+    if (!view) return false;
     const $el = view.$el;
     const blockHeight = Math.floor($el.height());
     const windowHeight = Math.floor($(window).height());
@@ -52,10 +53,20 @@ export default class Views {
     return view.model.findDescendantModels('component').every(model => model.isTypeGroup('question'));
   }
 
+  static isScrollingAtStart(view) {
+    if (!this.hasScrolling(view) || this.isQuestion(view)) return true;
+    const measure = view.$el.onscreen();
+    const isScrollComplete = parseInt(measure.top) >= -2;
+    return isScrollComplete;
+  }
+
   static isScrollingAtEnd(view) {
     if (!this.hasScrolling(view) || this.isQuestion(view)) return true;
     const measure = view.$el.onscreen();
-    return parseInt(measure.bottom) >= 0;
+    const isScrollComplete = parseInt(measure.bottom) >= -2;
+    // set on view so reset across page sessions
+    if (isScrollComplete) view._isScrollComplete = true;
+    return isScrollComplete;
   }
 
   static setLocationId() {

--- a/js/Wheel.js
+++ b/js/Wheel.js
@@ -1,4 +1,4 @@
-import Adapt from 'core/js/adapt';
+import Notify from 'core/js/notify';
 import Views from './Views';
 import State from './State';
 import Snap from './Snap';
@@ -28,22 +28,15 @@ export default class Wheel extends Backbone.Controller {
   }
 
   onWheel(event) {
-    if (Adapt.notify.stack.length > 0 || State.isAnimating) return;
-    const movement = this.getMovement(event);
-    if (this.processLocalScroll(movement)) return;
-    this.processSnap(movement);
+    if (Notify.stack.length > 0 || State.isAnimating) return;
+    const deltaY = event.deltaY;
+    if (this.processLocalScroll(deltaY)) return;
+    this.processSnap(deltaY);
   }
 
-  getMovement(event) {
-    const amount = Math.abs(event.deltaY);
+  processLocalScroll(deltaY) {
+    const amount = Math.abs(deltaY);
     this._lastAmount = amount;
-    return {
-      deltaY: event.deltaY,
-      amount
-    };
-  }
-
-  processLocalScroll({ deltaY, amount }) {
     const currentBlockView = Views.currentBlockView;
     if (!Views.hasScrolling(currentBlockView)) return false;
     const offset = Scroll.offset;
@@ -78,12 +71,13 @@ export default class Wheel extends Backbone.Controller {
     return true;
   }
 
-  processSnap({ deltaY, amount }) {
+  processSnap(deltaY) {
     /**
      * Remove the touchpad scroll events from after the peek of the scroll animation
      * - touchpad wheel events are more frequently, in smaller units and usually take a curve ramped up and then down
      * - mouse wheel events are usually a series of constant large units at a lower frequency
      */
+    const amount = Math.abs(deltaY);
     this._peakAmount = Math.max(this._peakAmount, amount);
     const isLessThanPeakAmount = (amount < this._peakAmount);
     if (isLessThanPeakAmount) return;
@@ -92,7 +86,7 @@ export default class Wheel extends Backbone.Controller {
     if (hasDirectionChanged) this.clearGesture();
     this._direction = currentDirection;
     this._totalAmount += amount;
-    this.onEnd(amount);
+    this.onEnd();
   }
 
   /**

--- a/js/adapt-scrollSnap.js
+++ b/js/adapt-scrollSnap.js
@@ -1,4 +1,6 @@
 import Adapt from 'core/js/adapt';
+import Focus from './Focus';
+import Notify from './Notify';
 import Wheel from './Wheel';
 import Swipe from './Swipe';
 import Keyboard from './Keyboard';
@@ -8,10 +10,11 @@ import Page from './Page';
 import Config from './Config';
 import Block from './Block';
 import State from './State';
+import Snap from './Snap';
 import Scroll from './Scroll';
 import './Trickle';
 import './Visua11y';
-import Snap from './Snap';
+import Menu from './Menu';
 
 class ScrollSnap extends Backbone.Controller {
 
@@ -23,7 +26,8 @@ class ScrollSnap extends Backbone.Controller {
     this._swipe = new Swipe();
     this._keyboard = new Keyboard();
     this._touch = new Touch();
-    State.canSnap = true;
+    this._focus = new Focus();
+    State.canSnap = false;
     this.reset();
     this.listenToOnce(Adapt, 'adapt:start', this.onAdaptStart);
   }
@@ -40,21 +44,29 @@ class ScrollSnap extends Backbone.Controller {
     }
     this._block.addEvents();
     this._wheel.addEvents();
+    this._focus.addEvents();
     if (Config.isSwipeEnabled) this._swipe.addEvents();
     this._keyboard.addEvents();
     this._touch.addEvents();
+    this._notify.addEvents();
+    this._menu.addEvents();
   }
 
   removeEvents() {
     this._block.removeEvents();
     this._wheel.removeEvents();
+    this._focus.removeEvents();
     this._swipe.removeEvents();
     this._keyboard.removeEvents();
     this._touch.removeEvents();
+    this._notify.removeEvents();
+    this._menu.removeEvents();
     Scroll.removeEvents();
   }
 
   onAdaptStart() {
+    this._notify = new Notify();
+    this._menu = new Menu();
     if (!Config.isEnabled) return;
     this._page.addEvents();
     this._device.addEvents();

--- a/js/navigation.jsx
+++ b/js/navigation.jsx
@@ -9,51 +9,61 @@ export default function Navigation(props) {
     _isEnabled,
     _isFirst,
     _isLast,
+    _isScrollAtStart,
     _isScrollAtEnd,
     _isStepLocked,
-    _buttons
+    _hasScrolling,
+    _isScrollComplete,
+    _buttons,
+    _prompts
   } = props;
 
   const {
     _previous,
     _next,
-    _last,
-    _scroll
+    _last
   } = _buttons;
+
+  const {
+    _scroll
+  } = _prompts;
 
   if (!_isVisible || !_isEnabled) return null;
 
   return (
     <div className={classes([
-      'scrollsnap__nav-btn-container',
-      _isFirst && 'is-first'
+      'scrollsnap__nav-inner',
+      _isFirst && 'is-first',
+      _hasScrolling && 'has-scrolling',
+      _isScrollComplete && 'is-scroll-complete',
+      _isComplete && 'is-complete'
     ])}>
 
-      {!_isFirst && _previous._isEnabled &&
+      {(!_isFirst || (_scroll._isEnabled && _hasScrolling && !_isScrollAtStart)) && _previous._isEnabled &&
       <button className={classes([
         'btn-text scrollsnap__nav-btn scrollsnap__nav-btn-previous js-btn-previous',
         _previous._classes
       ])}>
-        <div className='icon icon-controls-up'></div>
+        <div className='icon icon-controls-up' aria-hidden='true'></div>
         <div className='scrollsnap__nav-btn-text'>
           {_previous.label}
         </div>
       </button>
       }
 
-      {!_isLast && _next._isEnabled &&
+      {!_isLast && _next._isEnabled && (!_scroll._isEnabled || !_hasScrolling || _isScrollAtEnd) &&
       <button
         className={classes([
           'btn-text scrollsnap__nav-btn scrollsnap__nav-btn-next js-btn-next',
-          _isScrollAtEnd || !_scroll?._isEnabled || _isComplete ? _next._classes : _scroll._classes,
+          _next._classes,
           _isStepLocked && 'is-locked is-disabled'
         ])}
         disabled={_isStepLocked}
       >
         <div className='scrollsnap__nav-btn-text'>
-          {_isScrollAtEnd || !_scroll?._isEnabled || _isComplete ? _next.label : _scroll.label}
+          {_next.label}
         </div>
-        <div className='icon icon-controls-down'></div>
+        <div className='icon icon-controls-down' aria-hidden='true'></div>
       </button>
       }
 
@@ -62,10 +72,24 @@ export default function Navigation(props) {
         'btn-text scrollsnap__nav-btn scrollsnap__nav-btn-last js-btn-last',
         _last._classes
       ])}>
-        <div className='icon icon-controls-up'></div>
+        <div className='icon icon-controls-up' aria-hidden='true'></div>
         <div className='scrollsnap__nav-btn-text'>
           {_last.label}
         </div>
+      </button>
+      }
+
+      {_scroll._isEnabled && _hasScrolling && !_isScrollAtEnd &&
+      <button
+        className={classes([
+          'btn-text scrollsnap__nav-btn scrollsnap__nav-btn-next js-btn-next',
+          _scroll._classes
+        ])}
+      >
+        <div className='scrollsnap__nav-btn-text'>
+          {_scroll.label}
+        </div>
+        <div className='icon icon-controls-down' aria-hidden='true'></div>
       </button>
       }
 

--- a/less/navigation.less
+++ b/less/navigation.less
@@ -11,7 +11,7 @@
     .u-display-none;
   }
 
-  &-btn-container {
+  &-inner {
     display: flex;
     justify-content: center;
   }

--- a/less/scrollControls.less
+++ b/less/scrollControls.less
@@ -1,0 +1,36 @@
+.scrollsnap__controls {
+  position: fixed;
+  top: 0;
+  left: 0;
+  height: 0;
+  width: 100%;
+  z-index: 101;
+  overflow: visible;
+  display: none;
+
+  .no-touch .is-full-window& {
+    display: block;
+  }
+
+  &-inner {
+    position: relative;
+    max-width: 1200px;
+    margin: 0 auto;
+  }
+
+  &-btn {
+    position: absolute;
+    left: 50%;
+  }
+
+  &-btn-up {
+    transform: translateX(-50%);
+  }
+
+  &-btn-down {
+    transform: translate(-50%, -100%);
+    top: 100vh;
+  }
+
+
+}

--- a/templates/ScrollControls.jsx
+++ b/templates/ScrollControls.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+export default function NotifyScrollControls(props) {
+
+  return (
+    <div className='scrollsnap__controls-inner'>
+      <button
+        className='btn-icon scrollsnap__controls-btn scrollsnap__controls-btn-up'
+        onClick={props.onClick}
+        data-direction='up'
+      >
+        <div className='icon icon-controls-up' aria-hidden='true'></div>
+      </button>
+      <button
+        className='btn-icon scrollsnap__controls-btn scrollsnap__controls-btn-down'
+        onClick={props.onClick}
+        data-direction='down'
+      >
+        <div className='icon icon-controls-down' aria-hidden='true'></div>
+      </button>
+    </div>
+  );
+
+}


### PR DESCRIPTION
fixes #21
fixes #20
fixes #18

### Added
* Notify and menu scroll control arrows (for when touchpads don't work for scrolling)

### Changed
* Allow arrows to scroll overflowing content (for when touchpads don't work for scrolling)
* Updated line for _isSteplocked in navigation
* Documented _preScroll and _htmlClasses in the example.json

