### PR TITLE
Update: display padlock when scrollsnap button locked (fixes #55)

### DIFF
--- a/less/navigation.less
+++ b/less/navigation.less
@@ -30,6 +30,11 @@
     }
   }
 
+  // replace btn icon for padlock when locked
+  &-btn.is-locked .icon {
+    .icon-padlock-locked;
+  }
+  
   &.is-hidden,
   .is-hidden,
   .hide-if-locked.is-locked {


### PR DESCRIPTION
Fixes https://github.com/cgkineo/adapt-scrollSnap/issues/55

### Update
* Replace next/previous button icon with padlock when next block available is locked. 
 

### Testing
Enable `_scrollSnap` in your course as per [example](https://github.com/cgkineo/adapt-scrollSnap/blob/master/example.json).

Note, please test with components that require interaction. Not completion on inview.


**Next block is locked until question is complete (padlock icon displays)**
![next_btn_locked](https://github.com/user-attachments/assets/2f1d560d-e78c-42bc-8a46-a342384f9f58)

**Next block is unlocked now question is complete (default icon displays)**
![next_btn_unlocked](https://github.com/user-attachments/assets/1242db51-c099-487a-ab28-7d535d560d1b)
