### PR TITLE
Fix: allow bookmarking location to be restored

### DIFF
--- a/js/Page.js
+++ b/js/Page.js
@@ -1,6 +1,7 @@
 import Adapt from 'core/js/adapt';
 import Data from 'core/js/data';
 import Location from 'core/js/location';
+import a11y from 'core/js/a11y';
 import Classes from './Classes';
 import Models from './Models';
 import State from './State';
@@ -82,6 +83,10 @@ export default class Page extends Backbone.Controller {
     const options = { pluginName: 'scrollSnap' };
     // prevent scrolling without navigation offset and control via plugin
     Adapt.set('_canScroll', false, options);
+    if (a11y.isPopupOpen) {
+      this.listenToOnce(Adapt, 'popup:closed', this.onPageScrollTo.bind(this, selector, settings));
+      return;
+    }
     _.defer(() => {
       Adapt.set('_canScroll', true, options);
       let id = selector.replace('.', '');
@@ -92,7 +97,6 @@ export default class Page extends Backbone.Controller {
         id = model.get('_id');
       }
       if (!Models.isBlock(model)) return;
-      State.currentModel = model;
       Snap.toId(id, settings?.duration);
     });
   }

--- a/js/Page.js
+++ b/js/Page.js
@@ -78,7 +78,7 @@ export default class Page extends Backbone.Controller {
   }
 
   onPageScrollTo(selector, settings) {
-    if (!Config.canUseScrollSnap || !Config.getModelConfig(Adapt.parentView.model)?._isEnabled) return;
+    if (!Config.canUseScrollSnap || Config.getModelConfig(Adapt.parentView.model)?._isEnabled === false) return;
     const options = { pluginName: 'scrollSnap' };
     // prevent scrolling without navigation offset and control via plugin
     Adapt.set('_canScroll', false, options);


### PR DESCRIPTION
Fixes #62.

### Fix
* Allow bookmarking location to be restored. Wait for bookmarking dialog to be closed before attempting to restore any `_start._startIds`.