### PR TITLE
Update: Convert html selectors to CSS .html selectors (fixes #61)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # adapt-scrollSnap
+
 An extension which hides the scrollbar and snaps the scroll position to blocks for large devices. Navigation based on swipe gestures, specific keyboard navigation, the mouse wheel, and an optional scroll button.
 
 Content is set to fill the viewport height.
@@ -37,4 +38,11 @@ The following attributes are set within *course.json*:
 
 - Currently not setup to work with [**adapt-contrib-trickle**](https://github.com/adaptlearning/adapt-contrib-trickle). Instead, blocks are step-locked until completed. Mark blocks as _isOptional to disable step-locking.
 
-- Currently not setup to work with [**adapt-contrib-pageLevelProgress**](https://github.com/adaptlearning/adapt-contrib-). Do not use with other plugins that permit navigation (e.g. adapt-devtools map), including use of `Adapt.navigateToElement`.
+- Currently not setup to work with [**adapt-contrib-pageLevelProgress**](https://github.com/adaptlearning/adapt-contrib-pageLevelProgress). Do not use with other plugins that permit navigation (e.g. adapt-devtools map), including use of `Adapt.navigateToElement`.
+
+----------------------------
+
+**Author / maintainer:** CGKineo<br>
+**Accessibility support:** WAI AA<br>
+**RTL support:** Yes<br>
+**Cross-platform coverage:** Chrome, Chrome for Android, Firefox (ESR + latest version), Edge, Safari for macOS/iOS/iPadOS, Opera<br>

--- a/less/navigation.less
+++ b/less/navigation.less
@@ -1,4 +1,4 @@
-html.scrollSnap {
+.html.scrollSnap {
   .scrollsnap__nav {
     position: fixed;
     bottom: 0;

--- a/less/scrollControls.less
+++ b/less/scrollControls.less
@@ -1,4 +1,4 @@
-html.scrollSnap {
+.html.scrollSnap {
   .scrollsnap__controls {
     position: fixed;
     top: 0;

--- a/less/scrollSnap.less
+++ b/less/scrollSnap.less
@@ -1,4 +1,4 @@
-html.scrollSnap:not(.has-devtools-map) {
+.html.scrollSnap:not(.has-devtools-map) {
   &.location-page {
     overflow-x: hidden !important;
     overflow-y: hidden !important;

--- a/less/viewport.less
+++ b/less/viewport.less
@@ -1,4 +1,4 @@
-html.scrollSnap {
+.html.scrollSnap {
   .full-vh {
     min-height: calc(var(--adapt-viewport-height) - var(--adapt-navigation-height)) !important;
     padding-top: @navigation-height;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adapt-scrollSnap",
   "version": "5.3.0",
-  "framework": ">=5.31.3",
+  "framework": ">=5.46.4",
   "displayName": "ScrollSnap",
   "extension": "scrollSnap",
   "description": "An extension which hides the scrollbar and snaps to blocks. Content is set to fill the viewport height.",


### PR DESCRIPTION
Fix #61

### Update
* Convert `html` selectors to CSS `.html` selectors in Less

### Requires
Needs FW version bump:
* https://github.com/adaptlearning/adapt-contrib-core/pull/654
* https://github.com/adaptlearning/adapt_framework/pull/3681